### PR TITLE
Login: Use "dummysecret" if LDAP is disabled to avoid issues with the UI...

### DIFF
--- a/src/atlantis/manager/ldap/ldap.go
+++ b/src/atlantis/manager/ldap/ldap.go
@@ -120,7 +120,7 @@ func SessionExpiryRoutine() {
 
 func Login(user, pass, secret string) (string, error) {
 	if skipLogin {
-		return "", nil // just let everything pass
+		return "dummysecret", nil // just let everything pass
 	}
 	// Checking if we are already logged in
 	var LDAPConn *ldap.LDAPConnection


### PR DESCRIPTION
....

Hah.  Github's truncation of title name is silly.
