### PR TITLE
Dnsmasq

### DIFF
--- a/src/atlantis/manager/dns/dnsmasq.go
+++ b/src/atlantis/manager/dns/dnsmasq.go
@@ -170,7 +170,7 @@ func (d *DnsmasqProvider) DeleteRecords(region, comment string, ids ...string) (
 }
 
 func (d *DnsmasqProvider) Suffix(region string) (string, error) {
-	return "", nil
+	return "aquarium", nil
 }
 
 func NewDnsmasqProvider(file string) (*DnsmasqProvider, error) {


### PR DESCRIPTION
Creates a dnsmasq DNS provider for use with Aquarium.  Really just writes to /etc/hosts, and then uses dnsmasq and additional glue to make this available to all the components.
