### PR TITLE
Add poll delay to client.  When waiting, check with the server every 3 s...

### DIFF
--- a/src/atlantis/manager/client/task.go
+++ b/src/atlantis/manager/client/task.go
@@ -15,7 +15,10 @@ import (
 	. "atlantis/common"
 	. "atlantis/manager/rpc/types"
 	"errors"
+	"time"
 )
+
+const waitPollInterval = 3 * time.Second
 
 type StatusCommand struct {
 	ID string `short:"i" long:"id" description:"the task ID to fetch the status for"`
@@ -94,6 +97,7 @@ func (c *WaitCommand) Execute(args []string) error {
 		return OutputError(err)
 	}
 	for !statusReply.Done {
+		time.Sleep(waitPollInterval)
 		if currentStatus != statusReply.Status {
 			currentStatus = statusReply.Status
 			Log(currentStatus)


### PR DESCRIPTION
...econds, not continuously.

It turns out that this kind of hammers the server, and uses lots of CPU when everything is local.
