### PR TITLE
Delete rules from tries correctly.

### DIFF
--- a/src/atlantis/manager/datamodel/router.go
+++ b/src/atlantis/manager/datamodel/router.go
@@ -493,7 +493,7 @@ func CleanupCreatedPoolRefs(internal bool, app, sha, env string) error {
 	newRules := []string{}
 	for _, rule := range trie.Rules {
 		if rule != ruleName {
-			newRules = append(newRules, ruleName)
+			newRules = append(newRules, rule)
 		}
 	}
 	if len(trie.Rules) != len(newRules) {


### PR DESCRIPTION
When we delete a rule from a trie, we build up the new list, with the old rule
removed.  Previously, we were building up the list by repeatedly adding the
removed rule instead of the rule we're looping over.

This leads to fun issues.
