### PR TITLE
Code fix for manager API usage function not capturing user/secret form vals

### DIFF
--- a/src/atlantis/manager/api/status.go
+++ b/src/atlantis/manager/api/status.go
@@ -18,8 +18,9 @@ import (
 )
 
 func Usage(w http.ResponseWriter, r *http.Request) {
+	auth := ManagerAuthArg{r.FormValue("User"), "", r.FormValue("Secret")}
+	arg := ManagerUsageArg{ManagerAuthArg: auth}
 	var reply ManagerUsageReply
-	arg := ManagerUsageArg{}
 	err := manager.Usage(arg, &reply)
 	fmt.Fprintf(w, "%s", Output(map[string]interface{}{"Usage": reply.Usage}, err))
 }


### PR DESCRIPTION
Issue: https://github.com/ooyala/atlantis-manager/issues/66

The code changes should be self explanatory and follow the convention used by all the other api functions.