### PR TITLE
Fixing client test, added specific error and implemented config based tests

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -13,6 +13,7 @@ gom 'github.com/mavricknz/ldap', :commit => '6638977d26a6bc5ac0d2a9a5dcbefe02c45
 gom 'github.com/mewpkg/gopass', :commit => '3b39664481b57ad99d34c86bd64090c28eacc7a1'
 gom 'github.com/ooyala/go-jenkins-cli', :commit => 'b0d917efc4bf5e63f10e51a516ba0f54741f39dd'
 gom 'github.com/scalingdata/gozk', :commit => 'a7d78aed637bdb8d5372f0dc878c1ce05b9ffa0f'
+gom 'github.com/spf13/viper', :commit => '1967d93db724f4a5c0e101307e96d82ff520a067'
 
 gom 'atlantis', :command => 'git clone https://github.com/ooyala/atlantis.git', :skip_build => 'true', :vendor_path => 'lib'
 gom 'atlantis-builder', :command => 'git clone https://github.com/ooyala/atlantis-builder.git', :skip_build => 'true', :vendor_path => 'lib'

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ifdef TEST_PACKAGE
 	@echo "Testing $$TEST_PACKAGE..."
 	@go test $$TEST_PACKAGE $$VERBOSE $$RACE
 else
-	@for p in `find ./src -type f -name "*.go" |sed 's-\./src/\(.*\)/.*-\1-' |sort -u`; do \
+	@for p in `find ./src -type f -name "*_test.go" |sed 's-\./src/\(.*\)/.*-\1-' |sort -u`; do \
 		echo "Testing $$p..."; \
 		go test $$p || exit 1; \
 	done

--- a/src/atlantis/manager/client/client_test.go
+++ b/src/atlantis/manager/client/client_test.go
@@ -114,7 +114,7 @@ func checkCommand(t *testing.T, command interface{}, line string, expected inter
 }
 
 func TestRegisterApp(t *testing.T) {
-	testName := "e2e-test-" + time.Now().Format("2006-01-02T15-04-05-0700")
+	testName := "e2e-test-" + time.Now().Format("2006-01-02T15-04-05")
 
 	log.Print("== Registering dummy app ==")
 	registerCommand := &RegisterAppCommand{Name: testName, Repo: "fake-git-repo", Root: "/path/to/app",
@@ -163,7 +163,7 @@ func checkUrl(t *testing.T, url, name, expected string) bool {
 }
 
 func TestFullDeploy(t *testing.T) {
-	testName := "e2e-test-" + time.Now().Format("2006-01-02T15-04-05-0700")
+	testName := "e2e-test-" + time.Now().Format("2006-01-02T15-04-05")
 
 	checkCommand(t, &ListAppsCommand{}, "", &ManagerListAppsReply{[]string{"hello-go"}, "OK"})
 

--- a/src/atlantis/manager/rpc/router.go
+++ b/src/atlantis/manager/rpc/router.go
@@ -61,6 +61,10 @@ func (e *GetAppEnvPortExecutor) Execute(t *Task) (err error) {
 	zrp := datamodel.GetRouterPorts(zkApp.Internal)
 	fmt.Printf("ROUTER PORTS: %+v\n", zrp)
 	portStr := zrp.AppEnvMap[helper.GetAppEnvTrieName(e.arg.App, e.arg.Env)]
+	if portStr == "" {
+		return errors.New("port not found")
+	}
+
 	fmt.Printf("PORT STRING: %+v -> %+v\n", helper.GetAppEnvTrieName(e.arg.App, e.arg.Env), portStr)
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {

--- a/src/atlantis/manager/test_config.yml
+++ b/src/atlantis/manager/test_config.yml
@@ -1,9 +1,6 @@
 client:
-  # region: skunkworks
-  region: dev
-  # host: internal-router.us-east-1-skunkworks.atlantis.services.ooyala.com
-  host: internal-router.aquarium
+  region: skunkworks  # or dev
+  host: internal-router.us-east-1-skunkworks.atlantis.services.ooyala.com
   app: hello-go
-  # sha: 2b51bb16fa4efa0b1b591ed68217ac962398a60d
-  sha: ec8e09710831947f596079fdd9036f123a78de3c
+  sha: 2b51bb16fa4efa0b1b591ed68217ac962398a60d
   contact_group: edanaher-test

--- a/src/atlantis/manager/test_config.yml
+++ b/src/atlantis/manager/test_config.yml
@@ -1,0 +1,9 @@
+client:
+  # region: skunkworks
+  region: dev
+  # host: internal-router.us-east-1-skunkworks.atlantis.services.ooyala.com
+  host: internal-router.aquarium
+  app: hello-go
+  # sha: 2b51bb16fa4efa0b1b591ed68217ac962398a60d
+  sha: ec8e09710831947f596079fdd9036f123a78de3c
+  contact_group: edanaher-test

--- a/src/atlantis/manager/util/util.go
+++ b/src/atlantis/manager/util/util.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"github.com/spf13/viper"
+	"log"
+	"path/filepath"
+)
+
+// GetTestConfig : Return test config based on package name
+func GetTestConfig(packageName string) map[string]string {
+	path, _ := filepath.Abs("../")
+	viper.SetConfigName("test_config")
+	viper.AddConfigPath(path)
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalf("Error : %s", err)
+	}
+
+	return viper.GetStringMapString(packageName)
+}


### PR DESCRIPTION
* Getting error `App name must be ^[A-Za-z0-9-]+$` as `time.Now().Format("2006-01-02T15-04-05-0700")` is producing '+' in time(`2015-10-08T07-01-56+0000`) which regex doesn't allow.

* Added specific error of `port not found` during execution of `GetAppEnv` command.

* Test only packages containing test file(s).

* Added config based tests implementation